### PR TITLE
株価スクレイピングのHTML仕様変更対応（2025/12）

### DIFF
--- a/rails/app/stock_api/app/services/scraping/stock_price_scraper.rb
+++ b/rails/app/stock_api/app/services/scraping/stock_price_scraper.rb
@@ -50,7 +50,7 @@ class Scraping::StockPriceScraper < BaseService
   # @return [Enumerator<Array<String>>]  [日付, 終値, 調整後終値]の配列 例: [['2020年11月9日', '250', '125'], ...]
   def _extract_stock_prices(document)
     Enumerator.new do |y|
-      rows = document.css('table.StocksEtfReitPriceHistory__historyTable__13C_ tbody tr')
+      rows = document.css('table.styles_HistoryContainer__table__gJa53 tbody tr')
       last_ymd = nil
       rows.reverse_each do |tr|
         ymd = tr.css('th').text


### PR DESCRIPTION
### before

<img width="715" height="247" alt="image" src="https://github.com/user-attachments/assets/d2b3c878-a1f2-4b07-be4a-decdf1a64ebb" />

### after

<img width="633" height="255" alt="image" src="https://github.com/user-attachments/assets/c4055b7a-91a3-4b84-aa4e-a593ea1ad963" />
