### PR TITLE
株価スクレイピングは CSSクラスではなく id を見るように修正

### DIFF
--- a/rails/app/stock_api/app/services/scraping/stock_price_scraper.rb
+++ b/rails/app/stock_api/app/services/scraping/stock_price_scraper.rb
@@ -50,7 +50,7 @@ class Scraping::StockPriceScraper < BaseService
   # @return [Enumerator<Array<String>>]  [日付, 終値, 調整後終値]の配列 例: [['2020年11月9日', '250', '125'], ...]
   def _extract_stock_prices(document)
     Enumerator.new do |y|
-      rows = document.css('table.styles_HistoryContainer__table__gJa53 tbody tr')
+      rows = document.css('table#histlist tbody tr')
       last_ymd = nil
       rows.reverse_each do |tr|
         ymd = tr.css('th').text


### PR DESCRIPTION
fix #15

```sh
curl -v 'https://stock-api.neogenia.co.jp/inheritance?date=20260331&codes=1301'
```

### before

<img width="667" height="247" alt="スクリーンショット 2026-08-18 11 37 47" src="https://github.com/user-attachments/assets/1a6d0c4d-f849-49bd-9ec6-0e6c35b22fbd" />

### after

<img width="634" height="250" alt="スクリーンショット 2026-08-18 11 39 43" src="https://github.com/user-attachments/assets/830b8d1d-b3c6-485b-83ae-2bce2567f67a" />

